### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -156,8 +156,7 @@
         <% end %>
       </li>
       <% end %>
-    <% end %>
-      
+    <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,6 +173,7 @@
           </div>
         </div>
         <% end %>
+    <% end %>
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -157,10 +157,7 @@
       </li>
       <% end %>
     <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>


### PR DESCRIPTION
what
商品が一覧で見られるように実装しました

why
利用者にとって、商品が一覧で見られると、選ぶ際に便利だからです

ログイン中
https://gyazo.com/61a64193f453e2927920dd44c38ca370

ログアウト中
https://gyazo.com/3c8aacb312b29325828d465d0382dcf9

どちらの場合も商品が一覧表示されています
https://gyazo.com/e9fc117d24548445f997fe8838ab7a68

※「売却済みの商品は、『sold out』の文字が表示されるようになっていること」という機能に関しては、商品購入機能実装後に実装します